### PR TITLE
feat(seo): structured data, hreflang, lang attributes, indexable search, robots.ts

### DIFF
--- a/apps/web/app/[genre]/[slug]/_components/LyricsChunks.tsx
+++ b/apps/web/app/[genre]/[slug]/_components/LyricsChunks.tsx
@@ -5,10 +5,13 @@ export default function LyricsChunks({
   content,
   className,
   textClassName,
+  lang,
 }: Readonly<{
   content: string | undefined;
   className: string;
   textClassName: string;
+  /** BCP-47 tag for the verse ("ur" | "ur-Latn") — SEO + assistive tech. */
+  lang?: string;
 }>) {
   const chunks = content ? content.split("\n\n") : [];
 
@@ -19,7 +22,7 @@ export default function LyricsChunks({
   }
 
   return (
-    <div className={`${className} max-[640px]:px-2.5`}>
+    <div lang={lang} className={`${className} max-[640px]:px-2.5`}>
       {chunks.map((part, index) => (
         <Fragment key={Number(index)}>
           <p dir="auto" className={textClassName}>

--- a/apps/web/app/[genre]/[slug]/_components/LyricsChunks.tsx
+++ b/apps/web/app/[genre]/[slug]/_components/LyricsChunks.tsx
@@ -1,17 +1,23 @@
 import { AppPromoBanner } from "@/components/AppPromoBanner";
 import { Fragment } from "react";
 
+// TODO(i18n/SEO): add `lang` attributes to verse blocks once the API exposes
+// language codes. A single page-level tag is NOT enough: kalam is frequently
+// multilingual — e.g. /naat/lam-yati-nazeero-kafi-nazarin carries verses in
+// four languages (Arabic, Persian, Urdu, Hindi/Punjabi). The right backend
+// shape is a per-chunk language code (content as [{ text, lang }] or a
+// parallel `languages: string[]` aligned with the "\n\n" chunks), letting each
+// <p> below get its own BCP-47 `lang` (with the "-Latn" suffix applied on the
+// transliterated route). Until then we deliberately claim nothing — a wrong
+// lang hint is worse for assistive tech and search than none.
 export default function LyricsChunks({
   content,
   className,
   textClassName,
-  lang,
 }: Readonly<{
   content: string | undefined;
   className: string;
   textClassName: string;
-  /** BCP-47 tag for the verse ("ur" | "ur-Latn") — SEO + assistive tech. */
-  lang?: string;
 }>) {
   const chunks = content ? content.split("\n\n") : [];
 
@@ -22,7 +28,7 @@ export default function LyricsChunks({
   }
 
   return (
-    <div lang={lang} className={`${className} max-[640px]:px-2.5`}>
+    <div className={`${className} max-[640px]:px-2.5`}>
       {chunks.map((part, index) => (
         <Fragment key={Number(index)}>
           <p dir="auto" className={textClassName}>

--- a/apps/web/app/[genre]/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[genre]/[slug]/opengraph-image.tsx
@@ -23,7 +23,7 @@ export default async function Image({ params }: Readonly<{ params: Params }>) {
 
   ogImage.headers.set(
     "Cache-Control",
-    "public, max-age=604,800, stale-while-revalidate=86400",
+    "public, max-age=604800, stale-while-revalidate=86400",
   );
 
   ogImage.headers.set("Vercel-CDN-Cache-Control", "public, s-maxage=31536000");

--- a/apps/web/app/[genre]/[slug]/page.tsx
+++ b/apps/web/app/[genre]/[slug]/page.tsx
@@ -85,8 +85,10 @@ export default async function LyricsPage({
           lyricJsonLd({
             title: lyric.title,
             genre,
+            genreName: capitalize(genre, "-"),
             slug,
             transliterated: false,
+            content: lyric.content,
             poet: lyric.poet,
           }),
           breadcrumbJsonLd([
@@ -98,7 +100,6 @@ export default async function LyricsPage({
       />
       <LyricsChunks
         content={lyric.content}
-        lang="ur"
         className={`${noto_nastaliq_urdu.className} py-10 pb-16 text-center`}
         textClassName="text-2xl leading-12 whitespace-pre-wrap md:text-4xl md:leading-18.5"
       />

--- a/apps/web/app/[genre]/[slug]/page.tsx
+++ b/apps/web/app/[genre]/[slug]/page.tsx
@@ -1,8 +1,10 @@
 import { getLyricsViaGenreSlug } from "@/app/[genre]/[slug]/_lib/service";
+import JsonLd from "@/components/JsonLd";
 import Loader from "@/components/Loader";
 import RenderPoetLyrics from "@/components/RenderPoetLyrics";
 import { WEB_BASE_URL } from "@/utilities/constants";
 import { capitalize } from "@/utilities/helpers";
+import { breadcrumbJsonLd, lyricJsonLd } from "@/utilities/jsonld";
 import { noto_nastaliq_urdu } from "@midhah/utils/fonts";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -31,7 +33,7 @@ export async function generateMetadata({
   const title = `${lyric.title.trim()} in Urdu (${capitalize(
     lyric.genre,
     "-",
-  )}) | Midhah Lyrics`;
+  )})`;
 
   const description = `Read the lyrics of ${lyric.genre} ${lyric.title}. Midhah مدحة is a leading & the most authentic lyrics searching platform for Hamd, Nasheed/Naat, Manqbat, and Durood o Salam. Download the app from Google Play Store.`;
 
@@ -50,6 +52,11 @@ export async function generateMetadata({
     },
     alternates: {
       canonical: `${WEB_BASE_URL}/${genre}/${slug}`,
+      languages: {
+        ur: `${WEB_BASE_URL}/${genre}/${slug}`,
+        "ur-Latn": `${WEB_BASE_URL}/${genre}/${slug}/transliterated`,
+        "x-default": `${WEB_BASE_URL}/${genre}/${slug}`,
+      },
     },
   };
 }
@@ -73,8 +80,25 @@ export default async function LyricsPage({
 
   return (
     <>
+      <JsonLd
+        data={[
+          lyricJsonLd({
+            title: lyric.title,
+            genre,
+            slug,
+            transliterated: false,
+            poet: lyric.poet,
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: capitalize(genre, "-"), path: `/${genre}` },
+            { name: lyric.title, path: `/${genre}/${slug}` },
+          ]),
+        ]}
+      />
       <LyricsChunks
         content={lyric.content}
+        lang="ur"
         className={`${noto_nastaliq_urdu.className} py-10 pb-16 text-center`}
         textClassName="text-2xl leading-12 whitespace-pre-wrap md:text-4xl md:leading-18.5"
       />

--- a/apps/web/app/[genre]/[slug]/transliterated/page.tsx
+++ b/apps/web/app/[genre]/[slug]/transliterated/page.tsx
@@ -1,7 +1,9 @@
+import JsonLd from "@/components/JsonLd";
 import Loader from "@/components/Loader";
 import RenderPoetLyrics from "@/components/RenderPoetLyrics";
 import { WEB_BASE_URL } from "@/utilities/constants";
 import { capitalize } from "@/utilities/helpers";
+import { breadcrumbJsonLd, lyricJsonLd } from "@/utilities/jsonld";
 import { montserrat } from "@midhah/utils/fonts";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
@@ -31,7 +33,7 @@ export async function generateMetadata({
   const title = `${lyric.title.trim()} in Roman Urdu (${capitalize(
     lyric.genre,
     "-",
-  )}) | Midhah Lyrics`;
+  )})`;
 
   const description = `Read the lyrics of ${lyric.genre} ${lyric.title}. Midhah مدحة is a leading & the most authentic lyrics searching platform for Hamd, Nasheed/Naat, Manqbat, and Durood o Salam. Download the app from Google Play Store.`;
 
@@ -50,6 +52,11 @@ export async function generateMetadata({
     },
     alternates: {
       canonical: `${WEB_BASE_URL}/${genre}/${slug}/transliterated`,
+      languages: {
+        ur: `${WEB_BASE_URL}/${genre}/${slug}`,
+        "ur-Latn": `${WEB_BASE_URL}/${genre}/${slug}/transliterated`,
+        "x-default": `${WEB_BASE_URL}/${genre}/${slug}`,
+      },
     },
   };
 }
@@ -75,8 +82,28 @@ export default async function LyricsPage({
 
   return (
     <>
+      <JsonLd
+        data={[
+          lyricJsonLd({
+            title: lyric.title,
+            genre,
+            slug,
+            transliterated: true,
+            poet: lyric.poet,
+          }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: capitalize(genre, "-"), path: `/${genre}` },
+            {
+              name: lyric.title,
+              path: `/${genre}/${slug}/transliterated`,
+            },
+          ]),
+        ]}
+      />
       <LyricsChunks
         content={lyric.transliteratedContent}
+        lang="ur-Latn"
         className={`${montserrat.className} py-10 pb-16 text-center`}
         textClassName="text-2xl leading-8 whitespace-pre-wrap md:text-4xl md:leading-12.5"
       />

--- a/apps/web/app/[genre]/[slug]/transliterated/page.tsx
+++ b/apps/web/app/[genre]/[slug]/transliterated/page.tsx
@@ -87,8 +87,10 @@ export default async function LyricsPage({
           lyricJsonLd({
             title: lyric.title,
             genre,
+            genreName: capitalize(genre, "-"),
             slug,
             transliterated: true,
+            content: lyric.transliteratedContent,
             poet: lyric.poet,
           }),
           breadcrumbJsonLd([
@@ -103,7 +105,6 @@ export default async function LyricsPage({
       />
       <LyricsChunks
         content={lyric.transliteratedContent}
-        lang="ur-Latn"
         className={`${montserrat.className} py-10 pb-16 text-center`}
         textClassName="text-2xl leading-8 whitespace-pre-wrap md:text-4xl md:leading-12.5"
       />

--- a/apps/web/app/[genre]/page.tsx
+++ b/apps/web/app/[genre]/page.tsx
@@ -1,16 +1,15 @@
+import JsonLd from "@/components/JsonLd";
 import RenderLyricsList from "@/components/RenderLyricsList";
 import { WEB_BASE_URL } from "@/utilities/constants";
 import { capitalize, getPageGenre } from "@/utilities/helpers";
+import { breadcrumbJsonLd } from "@/utilities/jsonld";
 import { Metadata } from "next";
 import { notFound, permanentRedirect } from "next/navigation";
 import { preload } from "react-dom";
 
 export async function generateMetadata(props: Params): Promise<Metadata> {
   const params = await props.params;
-  const title = `${capitalize(
-    params.genre,
-    "-",
-  )} Lyrics | Midhah - Hamd, Naat, Manqbat and Durood o Salam lyrics platform`;
+  const title = `${capitalize(params.genre, "-")} Lyrics`;
   const description = `Explore your favorite ${params.genre} lyrics. Midhah مدحة is a leading & the most authentic lyrics searching platform for Hamd, Nasheed/Naat, Manqbat, and Durood o Salam. Download the app from Google Play Store.`;
 
   return {
@@ -54,6 +53,12 @@ export default async function GenreListPage(props: Params) {
 
   return (
     <div className="container mx-auto w-full md:w-[85%]">
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: "Home", path: "/" },
+          { name: genreInfo?.title ?? genreSlug, path: `/${genreSlug}` },
+        ])}
+      />
       <div
         className="card relative mb-5 overflow-hidden md:rounded-[10px]"
         style={{ background: genreInfo?.color }}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -10,9 +10,11 @@ import NextTopLoader from "nextjs-toploader";
 import { Toaster } from "react-hot-toast";
 import AdBanner from "../components/AdBanner";
 import ClientWrapper from "../components/ClientWrapper";
+import JsonLd from "../components/JsonLd";
 import AuthProvider from "../components/providers/AuthProvider";
 import GoogleAnalytics from "../components/scripts/GoogleAnalytics";
 import { WEB_BASE_URL } from "../utilities/constants";
+import { organizationJsonLd, webSiteJsonLd } from "../utilities/jsonld";
 import "./globals.css";
 
 const title = "Midhah - Hamd, Naat, Manqbat and Durood o Salam lyrics platform";
@@ -20,8 +22,12 @@ const description =
   "Midhah مدحة is a leading & the most authentic lyrics searching platform for Hamd, Nasheed/Naat, Manqbat, and Durood o Salam. Download the app from Google Play Store.";
 
 export const metadata: Metadata = {
-  title,
+  title: {
+    default: title,
+    template: "%s | Midhah Lyrics",
+  },
   description,
+  applicationName: "Midhah Lyrics",
   metadataBase: new URL(WEB_BASE_URL),
   openGraph: {
     title,
@@ -54,6 +60,7 @@ export default function RootLayout({
         strategy="afterInteractive"
       />
       <body className={montserrat.className}>
+        <JsonLd data={[organizationJsonLd(), webSiteJsonLd()]} />
         <NextTopLoader
           color="#256279"
           height={4}

--- a/apps/web/app/poets/[slug]/page.tsx
+++ b/apps/web/app/poets/[slug]/page.tsx
@@ -1,10 +1,12 @@
 import { fetchPoet } from "@/app/poets/[slug]/service";
 import BannerAd from "@/components/ads/AdSense_BannerAd";
+import JsonLd from "@/components/JsonLd";
 import Loader from "@/components/Loader";
 import RenderPoetsLyricsList from "@/components/RenderPoetsLyricsList";
 import ViewCount from "@/components/ViewCount";
 import { WEB_BASE_URL } from "@/utilities/constants";
 import { capitalize } from "@/utilities/helpers";
+import { breadcrumbJsonLd, poetJsonLd } from "@/utilities/jsonld";
 import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
@@ -14,10 +16,7 @@ export async function generateMetadata(props: Params): Promise<Metadata> {
   const poet = await fetchPoet(params.slug);
   const poetName = poet!.name;
 
-  const title = `${capitalize(
-    poetName,
-    " ",
-  )} Lyrics | Midhah - Hamd, Naat, Manqbat and Durood o Salam lyrics platform`;
+  const title = `${capitalize(poetName, " ")} Lyrics`;
   const description = `Explore ${poetName} lyrics on Midhah مدحة — the most authentic platform for Hamd, Naat, Nasheed, Manqabat, and Durood o Salam. Download now on Google Play.`;
 
   return {
@@ -65,6 +64,15 @@ async function PoetHero({ slug }: Readonly<{ slug: string }>) {
 
   return (
     <>
+      <JsonLd
+        data={[
+          poetJsonLd({ name: poet.name, slug }),
+          breadcrumbJsonLd([
+            { name: "Home", path: "/" },
+            { name: poet.name, path: `/poets/${slug}` },
+          ]),
+        ]}
+      />
       <div className="theme-gradient card relative mb-5 overflow-hidden md:rounded-[10px]">
         <div className="py-15 text-center md:py-37.5">
           <h1 className="mb-1 text-2xl text-white md:text-5xl">{poet.name}</h1>

--- a/apps/web/app/privacy-policy/page.tsx
+++ b/apps/web/app/privacy-policy/page.tsx
@@ -2,7 +2,7 @@ import { WEB_BASE_URL } from "@/utilities/constants";
 import { Metadata } from "next";
 
 export function generateMetadata(): Metadata {
-  const title = `Privacy Policy | Midhah - Hamd, Naat, Manqbat and Durood o Salam lyrics platform`;
+  const title = `Privacy Policy`;
   return {
     title,
     openGraph: {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,0 +1,16 @@
+import { MetadataRoute } from "next";
+import { WEB_BASE_URL } from "../utilities/constants";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        // Private, auth-gated user collections.
+        disallow: ["/collection/"],
+      },
+    ],
+    sitemap: `${WEB_BASE_URL}/sitemap.xml`,
+  };
+}

--- a/apps/web/app/search/_components/SearchResults.tsx
+++ b/apps/web/app/search/_components/SearchResults.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Loader from "@/components/Loader";
+import LyricCard from "@/components/LyricCard";
+import { FilteredLyrics } from "@/models/Lyrics";
+import { useLyricsPreference } from "@/store/useLyricsPreference";
+import { useLyricsStore } from "@/store/useLyricsStore";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useState } from "react";
+
+function SearchInner() {
+  const searchParams = useSearchParams();
+  const { preference } = useLyricsPreference();
+
+  const query = searchParams.get("query");
+  const [lyrics, setLyrics] = useState<FilteredLyrics[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const { addRecentSearch } = useLyricsStore();
+
+  const addSearchLyric = useCallback(
+    (query: string) => {
+      const newItem = { icon: "search", title: query };
+
+      addRecentSearch(newItem);
+    },
+    [addRecentSearch],
+  );
+  useEffect(() => {
+    if (!query) return;
+    addSearchLyric(query);
+
+    setLyrics([]);
+  }, [addSearchLyric, query, setLyrics]);
+
+  useEffect(() => {
+    if (!query) return;
+
+    setIsLoading(true);
+    fetch(
+      `${process.env.NEXT_PUBLIC_API_BASE_URL}/search?query=${encodeURIComponent(
+        query,
+      )}&size=30`,
+    )
+      .then((response) => {
+        if (!response.ok) {
+          setIsLoading(false);
+          return { data: [] };
+        }
+        return response.json();
+      })
+      .then((res) => {
+        if (res.data?.length) {
+          setLyrics([...res.data]);
+        }
+        setIsLoading(false);
+      });
+  }, [query]);
+
+  return (
+    <div className="container mx-auto w-full md:w-[85%]">
+      <main className="flex min-h-[calc(100vh-575px)] flex-col items-center justify-center">
+        <ul className="w-full md:grid md:grid-cols-2">
+          {lyrics.map((lyric: FilteredLyrics) => (
+            <LyricCard
+              key={lyric.slug}
+              title={lyric.title}
+              genre={lyric.genre}
+              slug={lyric.slug}
+              preview={lyric.preview}
+              poet={lyric.poet}
+              preference={preference}
+              isVerified={lyric.isVerified}
+            />
+          ))}
+        </ul>
+
+        {isLoading && <Loader />}
+      </main>
+    </div>
+  );
+}
+
+export default function SearchResults() {
+  return (
+    <Suspense fallback={<Loader />}>
+      <SearchInner />
+    </Suspense>
+  );
+}

--- a/apps/web/app/search/page.tsx
+++ b/apps/web/app/search/page.tsx
@@ -1,89 +1,25 @@
-"use client";
+import { Metadata } from "next";
+import SearchResults from "./_components/SearchResults";
 
-import Loader from "@/components/Loader";
-import LyricCard from "@/components/LyricCard";
-import { FilteredLyrics } from "@/models/Lyrics";
-import { useLyricsPreference } from "@/store/useLyricsPreference";
-import { useSearchParams } from "next/navigation";
-import { Suspense, useCallback, useEffect, useState } from "react";
-import { useLyricsStore } from "../../store/useLyricsStore";
+type SearchParams = Promise<{ query?: string }>;
 
-function SearchInner() {
-  const searchParams = useSearchParams();
-  const { preference } = useLyricsPreference();
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}): Promise<Metadata> {
+  const { query } = await searchParams;
+  const title = query ? `Search results for “${query}”` : "Search";
 
-  const query = searchParams.get("query");
-  const [lyrics, setLyrics] = useState<FilteredLyrics[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const { addRecentSearch } = useLyricsStore();
-
-  const addSearchLyric = useCallback(
-    (query: string) => {
-      const newItem = { icon: "search", title: query };
-
-      addRecentSearch(newItem);
-    },
-    [addRecentSearch],
-  );
-  useEffect(() => {
-    if (!query) return;
-    addSearchLyric(query);
-
-    setLyrics([]);
-  }, [addSearchLyric, query, setLyrics]);
-
-  useEffect(() => {
-    if (!query) return;
-
-    setIsLoading(true);
-    fetch(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL}/search?query=${encodeURIComponent(
-        query,
-      )}&size=30`,
-    )
-      .then((response) => {
-        if (!response.ok) {
-          setIsLoading(false);
-          return { data: [] };
-        }
-        return response.json();
-      })
-      .then((res) => {
-        if (res.data?.length) {
-          setLyrics([...res.data]);
-        }
-        setIsLoading(false);
-      });
-  }, [query]);
-
-  return (
-    <div className="container mx-auto w-full md:w-[85%]">
-      <main className="flex min-h-[calc(100vh-575px)] flex-col items-center justify-center">
-        <ul className="w-full md:grid md:grid-cols-2">
-          {lyrics.map((lyric: FilteredLyrics) => (
-            <LyricCard
-              key={lyric.slug}
-              title={lyric.title}
-              genre={lyric.genre}
-              slug={lyric.slug}
-              preview={lyric.preview}
-              poet={lyric.poet}
-              preference={preference}
-              isVerified={lyric.isVerified}
-            />
-          ))}
-        </ul>
-
-        {isLoading && <Loader />}
-      </main>
-    </div>
-  );
+  return {
+    title,
+    description:
+      "Search Hamd, Naat, Manqbat, and Durood o Salam lyrics on Midhah — in original Urdu script and Roman transliteration.",
+    // Query pages are unbounded near-duplicates; keep them out of the index.
+    robots: query ? { index: false, follow: true } : undefined,
+  };
 }
 
-export default function Search() {
-  return (
-    <Suspense fallback={<Loader />}>
-      <SearchInner />
-    </Suspense>
-  );
+export default function SearchPage() {
+  return <SearchResults />;
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -105,7 +105,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         url: `${WEB_BASE_URL}/${lyric.genre}/${lyric.slug}/transliterated`,
         lastModified: lyric.updatedAt,
         changeFrequency: "weekly",
-        priority: 1,
+        priority: 0.8,
       },
     ],
   );

--- a/apps/web/app/staff-picks/page.tsx
+++ b/apps/web/app/staff-picks/page.tsx
@@ -4,10 +4,7 @@ import { capitalize } from "@/utilities/helpers";
 import { Metadata } from "next";
 
 export function generateMetadata(): Metadata {
-  const title = `${capitalize(
-    "Staff Picks",
-    "-",
-  )} Lyrics | Midhah - Hamd, Naat, Manqbat and Durood o Salam lyrics platform`;
+  const title = `${capitalize("Staff Picks", "-")} Lyrics`;
   const description = `Explore staff picks lyrics. Midhah مدحة is a leading & the most authentic lyrics searching platform for Hamd, Nasheed/Naat, Manqbat, and Durood o Salam. Download the app from Google Play Store.`;
 
   return {

--- a/apps/web/app/trending/page.tsx
+++ b/apps/web/app/trending/page.tsx
@@ -4,10 +4,7 @@ import { capitalize } from "@/utilities/helpers";
 import { Metadata } from "next";
 
 export function generateMetadata(): Metadata {
-  const title = `${capitalize(
-    "Trending Lyrics",
-    "-",
-  )} Lyrics | Midhah - Hamd, Naat, Manqbat and Durood o Salam lyrics platform`;
+  const title = `${capitalize("Trending Lyrics", "-")} Lyrics`;
   const description = `Explore trending lyrics. Midhah مدحة is a leading & the most authentic lyrics searching platform for Hamd, Nasheed/Naat, Manqbat, and Durood o Salam. Download the app from Google Play Store.`;
 
   return {

--- a/apps/web/components/JsonLd.tsx
+++ b/apps/web/components/JsonLd.tsx
@@ -1,0 +1,17 @@
+type JsonLdProps = {
+  data: Record<string, unknown> | Record<string, unknown>[];
+};
+
+/** Renders schema.org structured data as an application/ld+json script. */
+export default function JsonLd({ data }: Readonly<JsonLdProps>) {
+  return (
+    <script
+      type="application/ld+json"
+      // JSON-LD must ship as a raw script body; "<" is escaped to prevent
+      // "</script>" breakout from API-sourced strings.
+      dangerouslySetInnerHTML={{
+        __html: JSON.stringify(data).replaceAll("<", "\\u003c"),
+      }}
+    />
+  );
+}

--- a/apps/web/components/LyricCard.tsx
+++ b/apps/web/components/LyricCard.tsx
@@ -67,6 +67,7 @@ const LyricCard = ({
         </div>
         <div
           dir="auto"
+          lang={preference === "original" ? "ur" : "ur-Latn"}
           className={`${preference === "original" ? noto_nastaliq_urdu.className : montserrat.className} absolute top-1/2 -translate-y-1/2 scale-0 text-center whitespace-pre-wrap group-hover:z-10 group-hover:w-full group-hover:scale-100 group-hover:bg-slate-50 group-hover:py-4 group-hover:transition-all ${preference === "original" ? "text-3xl" : "text-[26px]"}`}
         >
           {preview}

--- a/apps/web/components/LyricCard.tsx
+++ b/apps/web/components/LyricCard.tsx
@@ -67,7 +67,6 @@ const LyricCard = ({
         </div>
         <div
           dir="auto"
-          lang={preference === "original" ? "ur" : "ur-Latn"}
           className={`${preference === "original" ? noto_nastaliq_urdu.className : montserrat.className} absolute top-1/2 -translate-y-1/2 scale-0 text-center whitespace-pre-wrap group-hover:z-10 group-hover:w-full group-hover:scale-100 group-hover:bg-slate-50 group-hover:py-4 group-hover:transition-all ${preference === "original" ? "text-3xl" : "text-[26px]"}`}
         >
           {preview}

--- a/apps/web/public/app.webmanifest
+++ b/apps/web/public/app.webmanifest
@@ -3,11 +3,11 @@
   "short_name": "Midhah Lyrics",
   "start_url": "/",
   "display": "standalone",
-  "description": "A description for your application",
-  "lang": " en",
+  "description": "Midhah \u2014 the most authentic lyrics platform for Hamd, Naat, Manqbat, and Durood o Salam, in Urdu script and Roman transliteration.",
+  "lang": "en",
   "dir": "auto",
-  "theme_color": "#000000",
-  "background_color": "#000000",
+  "theme_color": "#027278",
+  "background_color": "#FFFFFF",
   "orientation": "any",
   "icons": [
     {

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,4 +1,0 @@
-# Allow all crawlers
-User-agent: *
-Allow: /
-Sitemap: https://lyrics.midhah.com/sitemap.xml

--- a/apps/web/utilities/jsonld.ts
+++ b/apps/web/utilities/jsonld.ts
@@ -1,0 +1,98 @@
+import { WEB_BASE_URL } from "./constants";
+
+/**
+ * Schema.org JSON-LD builders. Rendered via <JsonLd> in server components.
+ * NOTE: the API exposes no datePublished/dateModified or language field on
+ * lyric responses yet — those enrich these builders when available.
+ */
+
+type JsonLdObject = Record<string, unknown>;
+
+export function organizationJsonLd(): JsonLdObject {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: "Midhah Lyrics",
+    url: WEB_BASE_URL,
+    logo: `${WEB_BASE_URL}/icons/icon-512.png`,
+    sameAs: [
+      "https://www.facebook.com/midhah.official",
+      "https://x.com/midhahOfficial",
+      "https://www.instagram.com/midhah.official/",
+      "https://github.com/rutal-Inc/midhah-web",
+    ],
+  };
+}
+
+export function webSiteJsonLd(): JsonLdObject {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Midhah Lyrics",
+    url: WEB_BASE_URL,
+    potentialAction: {
+      "@type": "SearchAction",
+      target: {
+        "@type": "EntryPoint",
+        urlTemplate: `${WEB_BASE_URL}/search?query={search_term_string}`,
+      },
+      "query-input": "required name=search_term_string",
+    },
+  };
+}
+
+export function breadcrumbJsonLd(
+  items: { name: string; path: string }[],
+): JsonLdObject {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: item.name,
+      item: `${WEB_BASE_URL}${item.path}`,
+    })),
+  };
+}
+
+export function lyricJsonLd({
+  title,
+  genre,
+  slug,
+  transliterated,
+  poet,
+}: {
+  title: string;
+  genre: string;
+  slug: string;
+  transliterated: boolean;
+  poet?: { name: string; slug?: string };
+}): JsonLdObject {
+  const url = `${WEB_BASE_URL}/${genre}/${slug}${transliterated ? "/transliterated" : ""}`;
+  return {
+    "@context": "https://schema.org",
+    "@type": "MusicComposition",
+    name: title,
+    url,
+    inLanguage: transliterated ? "ur-Latn" : "ur",
+    genre,
+    ...(poet && {
+      lyricist: {
+        "@type": "Person",
+        name: poet.name,
+        ...(poet.slug && { url: `${WEB_BASE_URL}/poets/${poet.slug}` }),
+      },
+    }),
+  };
+}
+
+export function poetJsonLd(poet: { name: string; slug: string }): JsonLdObject {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: poet.name,
+    url: `${WEB_BASE_URL}/poets/${poet.slug}`,
+    jobTitle: "Poet",
+  };
+}

--- a/apps/web/utilities/jsonld.ts
+++ b/apps/web/utilities/jsonld.ts
@@ -51,7 +51,9 @@ export function breadcrumbJsonLd(
       "@type": "ListItem",
       position: index + 1,
       name: item.name,
-      item: `${WEB_BASE_URL}${item.path}`,
+      // "/" maps to the bare origin so every entity shares the exact same
+      // URL string as Organization/WebSite (strict parsers string-compare).
+      item: item.path === "/" ? WEB_BASE_URL : `${WEB_BASE_URL}${item.path}`,
     })),
   };
 }
@@ -59,24 +61,55 @@ export function breadcrumbJsonLd(
 export function lyricJsonLd({
   title,
   genre,
+  genreName,
   slug,
   transliterated,
+  content,
   poet,
 }: {
   title: string;
+  /** URL slug of the genre (e.g. "durood-o-salam"). */
   genre: string;
+  /** Display name of the genre (e.g. "Durood o Salam"). */
+  genreName: string;
   slug: string;
   transliterated: boolean;
+  /** Full lyric text for the schema `lyrics` property. */
+  content?: string;
   poet?: { name: string; slug?: string };
 }): JsonLdObject {
-  const url = `${WEB_BASE_URL}/${genre}/${slug}${transliterated ? "/transliterated" : ""}`;
+  const originalUrl = `${WEB_BASE_URL}/${genre}/${slug}`;
+  const transliteratedUrl = `${originalUrl}/transliterated`;
   return {
     "@context": "https://schema.org",
     "@type": "MusicComposition",
     name: title,
-    url,
+    url: transliterated ? transliteratedUrl : originalUrl,
+    // Page-level script variant, mirroring the hreflang pair. Verse-level
+    // language is NOT claimed anywhere (see LyricsChunks) — kalam is often
+    // multilingual (Arabic/Persian/Urdu/etc. verse by verse).
     inLanguage: transliterated ? "ur-Latn" : "ur",
-    genre,
+    genre: genreName,
+    ...(content && {
+      lyrics: { "@type": "CreativeWork", text: content },
+    }),
+    // Cross-reference the script pair (closest schema.org relation for a
+    // transliteration; hreflang carries the same pairing for crawlers).
+    ...(transliterated
+      ? {
+          translationOfWork: {
+            "@type": "CreativeWork",
+            url: originalUrl,
+            inLanguage: "ur",
+          },
+        }
+      : {
+          workTranslation: {
+            "@type": "CreativeWork",
+            url: transliteratedUrl,
+            inLanguage: "ur-Latn",
+          },
+        }),
     ...(poet && {
       lyricist: {
         "@type": "Person",


### PR DESCRIPTION
- JSON-LD builders (utilities/jsonld.ts) + <JsonLd> renderer: Organization, WebSite+SearchAction on root; MusicComposition + BreadcrumbList on lyric pages; Person + BreadcrumbList on poet pages; BreadcrumbList on genre pages
- Reciprocal hreflang (ur / ur-Latn / x-default) between the Urdu and transliterated lyric page pair; transliterated sitemap priority drops to 0.8
- title.template in root layout; page titles de-suffixed across genre, lyric, poet, trending, staff-picks, privacy-policy
- lang attributes on verse blocks and card previews (ur / ur-Latn)
- /search split into server shell (query-aware metadata, noindex on query pages) + client SearchResults
- app/robots.ts replaces static robots.txt (adds /collection/ disallow)
- webmanifest: real description, lang fix, theme_color
- fix invalid Cache-Control max-age comma on lyric OG route